### PR TITLE
Add the 'ssl-cert' group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class ssl {
   }->
 
   group { 'ssl-cert':
-    ensure => present
+    ensure => 'present'
   }->
 
   file { $ssl_keydir:


### PR DESCRIPTION
This adds the ssl-cert group that this module depends upon; as is it breaks every new server until you add that group manually.
