### PR TITLE
Merge long-running ssl_group branch into master

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,10 @@ class ssl {
     mode   => '0755',
   }->
 
+  group { 'ssl-cert':
+    ensure => 'present'
+  }->
+
   file { $ssl_keydir:
     ensure => directory,
     group  => 'ssl-cert',


### PR DESCRIPTION
We've been running on the ssl_group branch for a long time; I think it would make sense to merge into master.

Note: do not delete the ssl_group branch as github will prompt until we update it in the Puppetfile for all the major branches, or else they won't deploy properly.
