### PR TITLE
Enable concat_newline setting in ssl::cert

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -76,6 +76,10 @@ define ssl::cert (
     mode  => $mode,
   }
 
+  Concat {
+    ensure_newline => true,
+  }
+
   case $concat {
     'haproxy': { ## combine cert, key, and intermediate cert files
       $unified_cert = "${certdir}/${certfile}"


### PR DESCRIPTION
Enable concat_newline on all use of concat in ssl::cert defined type

Without this commit, SSL certificates, key files, intermediate chains,
etc that get concatenated together can generate unusable combined files
if any of the input fragments lack a newline at the end of the file. In
that case, nginx/haproxy/apache will fail to start.

This commit uses the concat_newline parameter to ensure that all
fragments have trailing newlines, even if the input files lack them.