### PR TITLE
Set default SSL certificate permissions to 0640

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -47,7 +47,7 @@ define ssl::cert (
   $concat        = false,
   $user          = 'root',
   $group         = 'root',
-  $mode          = '0644',
+  $mode          = '0640',
   ) {
   include ssl
   include ssl::params


### PR DESCRIPTION
This sets the default file permissions for SSL certificates to 0640, instead of 0644.

Without this change, the default configuration leaves private SSL certificate data readable by non-root users who should not have access to it.