### PR TITLE
Add define to generate hash files for certs.

### DIFF
--- a/manifests/hashfile.pp
+++ b/manifests/hashfile.pp
@@ -1,0 +1,14 @@
+define ssl::hashfile(
+  $certdir,
+) {
+
+  $filename = reverse(split($name, '/'))[0]
+
+  # Create certificate hash file
+  exec { "Build cert hash for ${filename}":
+    command => "ln -s ${certdir}/${filename} ${certdir}/$(openssl x509 -noout -hash -in ${certdir}/${filename}).0",
+    unless  => "test -f ${certdir}/$(openssl x509 -noout -hash -in ${certdir}/${filename}).0",
+    require => File["${certdir}/${filename}"],
+    path    => [ '/bin', '/usr/bin', '/usr/local/bin' ],
+  }
+}


### PR DESCRIPTION
  This commit will introduce a defined type that generates symlinks
  in the chosen SSL directory that are named the certificate's hash and
  linked to the actual certificate.

  Without the ability to generate these hashes we are unable to validate
  remote certificates via the LDAP or OpenSSL clients.