### PR TITLE
Remove switch on PE for ca_server

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -64,11 +64,7 @@ define ssl::cert (
     $keydir = $dest_keydir
   }
 
-  if $::is_pe == true {
-    $secure_server = hiera('pe_caserver')
-  } else {
-    $secure_server  = hiera('puppetlabs::ssl::secure_server', $::caserver)
-  }
+  $secure_server  = hiera('puppetlabs::ssl::secure_server', $::caserver)
 
   File {
     owner => $user,


### PR DESCRIPTION
We no longer have a pe_caserver hiera variable, and don't need to differentiate between pe and foss puppet behaviors here.