### PR TITLE
Make sure key file isn't world readable

### DIFF
--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -81,6 +81,9 @@ define ssl::cert (
 
   Concat {
     ensure_newline => true,
+    owner => $user,
+    group => $group,
+    mode  => $mode,
   }
 
   case $concat {
@@ -88,6 +91,7 @@ define ssl::cert (
       $unified_cert = "${certdir}/${certfile}"
       concat { $unified_cert:
         ensure => 'present',
+        mode   => '0400',
       }
       concat::fragment{ "${name}_server_cert":
         target => $unified_cert,

--- a/manifests/cert.pp
+++ b/manifests/cert.pp
@@ -49,8 +49,8 @@ define ssl::cert (
   $group         = 'root',
   $mode          = '0640',
   ) {
-  include ssl
-  include ssl::params
+  include ::ssl
+  include ::ssl::params
 
   if $dest_certdir == '' {
     $certdir = $::ssl::params::ssl_certdir


### PR DESCRIPTION
This also uses the passed permissions for other files generated by concat.