### PR TITLE
Actually only manage ssldir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,21 +28,23 @@ class ssl (
     file { $ssl_dir:
       ensure => directory,
       mode   => '0755',
-    }->
-
-    file { $ssl_certdir:
-      ensure => directory,
-      mode   => '0755',
-    }->
-
-    group { 'ssl-cert':
-      ensure => 'present'
-    }->
-
-    file { $ssl_keydir:
-      ensure => directory,
-      group  => 'ssl-cert',
-      mode   => '0750',
     }
+  }
+
+  file { $ssl_certdir:
+    ensure  => directory,
+    mode    => '0755',
+    require => File["${ssl_dir}"],
+  }
+
+  group { 'ssl-cert':
+    ensure => 'present'
+  }
+
+  file { $ssl_keydir:
+    ensure  => directory,
+    group   => 'ssl-cert',
+    mode    => '0750',
+    require => Group['ssl-cert'],
   }
 }


### PR DESCRIPTION
We still need subdirs managed by this module, so the optional
manage_ssl_dir setting actually only manages the ssldir now