### PR TITLE
Use eyaml to store SSL private keys

### DIFF
--- a/functions/ensure_newline.pp
+++ b/functions/ensure_newline.pp
@@ -1,0 +1,10 @@
+# Ensure there's a trailing newline
+function ssl::ensure_newline (
+  String[0] $string,
+) {
+  if $string[-1] == "\n" {
+    $string
+  } else {
+    "${string}\n"
+  }
+}

--- a/functions/pem/join.pp
+++ b/functions/pem/join.pp
@@ -1,0 +1,6 @@
+# Join certs and keys into a single PEM. Ensure the correct newlines exist.
+function ssl::pem::join (
+  Array[String[0]] $items,
+) {
+  $items.map |$item| { ssl::ensure_newline($item) }.join("")
+}

--- a/manifests/cert/haproxy.pp
+++ b/manifests/cert/haproxy.pp
@@ -1,0 +1,31 @@
+# Install key and certs combination for HAProxy.
+#
+# See the README for information about how to store certificates and keys for
+# use by this type.
+#
+# This deploys `/etc/haproxy/certs.d/${key_name}.crt`, which contains:
+#
+#   1. The primary certificate
+#   2. The private key
+#   3. The intermediate certificate(s)
+define ssl::cert::haproxy (
+  String[1] $key_name = $title,
+  String[1] $path     = "/etc/haproxy/certs.d/${key_name}.crt",
+  String[1] $user     = 'root',
+  String[1] $group    = '0',
+  String[1] $mode     = '0400',
+) {
+  include ssl
+
+  file { $path:
+    ensure  => file,
+    owner   => $user,
+    group   => $group,
+    mode    => $mode,
+    content => ssl::pem::join([
+      file("${ssl::cert_source}/${key_name}.crt"),
+      $ssl::keys[$key_name],
+      file("${ssl::cert_source}/${key_name}_inter.crt"),
+    ]),
+  }
+}

--- a/manifests/cert/nginx.pp
+++ b/manifests/cert/nginx.pp
@@ -1,16 +1,10 @@
-# Deploy SSL certificates and keys in a couple of common formats
+# DEPRECATED
 #
-# See the README for information about how to store certificates and keys for
-# use by this type.
+# This is only here to simplify some of our legacy code.
 #
-# This deploys:
-#
-#   * `${key_dir}/${key_name}.key`
-#   * `${cert_dir}/${key_name}.crt`
-#   * `${cert_dir}/${key_name}_inter.crt` — the intermediate certificate(s)
-#   * `${cert_dir}/${key_name}_combined.crt` — the primary certificate
-#     followed by the intermediate certificate(s)
-define ssl::cert (
+# We recommend using `ssl::cert` and configuring NGINX to use the
+# `_combined.crt` file instead of using this resource.
+define ssl::cert::nginx (
   String[1]           $key_name = $title,
   Optional[String[1]] $cert_dir = undef,
   Optional[String[1]] $key_dir  = undef,
@@ -36,16 +30,8 @@ define ssl::cert (
       # https://github.com/voxpupuli/hiera-eyaml/issues/264: eyaml drops newline
       content => ssl::ensure_newline($ssl::keys[$key_name]),
     ;
-    # Plain cert
-    "${_cert_dir}/${key_name}.crt":
-      content => file("${ssl::cert_source}/${key_name}.crt"),
-    ;
-    # Intermediate cert
-    "${_cert_dir}/${key_name}_inter.crt":
-      content => file("${ssl::cert_source}/${key_name}_inter.crt"),
-    ;
     # Combined cert and intermediate cert
-    "${_cert_dir}/${key_name}_combined.crt":
+    "${_cert_dir}/${key_name}.crt":
       content => ssl::pem::join([
         file("${ssl::cert_source}/${key_name}.crt"),
         file("${ssl::cert_source}/${key_name}_inter.crt"),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,50 +1,64 @@
-# Class: ssl
+# Maintain SSL certs and private keys
 #
-# This class maintains the permissions of the various directories used for SSL
-# deployments.
+# You can store SSL certs in your control repo. Simply create a profile and put
+# the certs in its files directory. (Note that you don't actually have to create
+# a manifest for it.)
 #
+# Suppose you wanted to use profile::ssl. Set `cert_source => 'profile/ssl'`,
+# and add cert files in site/profile/files/ssl/.
+#
+# You can also store SSL keys. These should be encrypted, and the simplest
+# solution for that is hiera-eyaml. Simply add keys to the keys parameter on
+# this class in hiera. For example:
+#
+#     ssl::keys:
+#       'puppet.com': ENC[PKCS7,MIIH...
+#       'forge.puppet.com': ENC[PKCS7,MIIH...
+#
+# The two most important parameters are:
+#
+#   $cert_source - Where to find cert files with the file() function.
+#   $keys - Private keys indexed by key names.
 class ssl (
-  Boolean $manage_ssl_dir = true
+  String[1]                  $cert_source,
+  Hash[String[1], String[1]] $keys           = {},
+  Boolean                    $manage_ssl_dir = true,
 ) {
-
+  # This doesn't quite follow the params pattern. Unfortunately, we have code
+  # that relies on variables in ssl::params, but doesn't actually need the
+  # directories managed. This is the simplest way to handle that legacy code.
+  #
+  # The PR I'm currently working on is getting too big, so I will leave
+  # refactoring this to a future change.
   include ssl::params
-
-  $ssl_dir              = $ssl::params::ssl_dir
-  $ssl_certdir          = $ssl::params::ssl_certdir
-  $ssl_keydir           = $ssl::params::ssl_keydir
-  $ssl_default_certpath = $ssl::params::ssl_default_certpath
-  $ssl_default_keypath  = $ssl::params::ssl_default_keypath
-
-  if ! $ssl_dir {
-    fail('ssl management is not built for this osfamily')
-  }
-
-  File {
-    owner => 'root',
-    group => '0',
-  }
+  $ssl_dir = $ssl::params::ssl_dir
+  $cert_dir = $ssl::params::cert_dir
+  $key_dir = $ssl::params::key_dir
 
   if $manage_ssl_dir {
     file { $ssl_dir:
       ensure => directory,
+      owner  => 'root',
+      group  => '0',
       mode   => '0755',
     }
   }
 
-  file { $ssl_certdir:
-    ensure  => directory,
-    mode    => '0755',
-    require => File["${ssl_dir}"],
+  file { $cert_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => '0',
+    mode   => '0755',
   }
 
   group { 'ssl-cert':
-    ensure => 'present'
+    ensure => present,
   }
 
-  file { $ssl_keydir:
-    ensure  => directory,
-    group   => 'ssl-cert',
-    mode    => '0750',
-    require => Group['ssl-cert'],
+  file { $key_dir:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'ssl-cert',
+    mode   => '0750',
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,44 +1,24 @@
-# Class: ssl::params
-#
-# Sets paramters for SSL used in the deployment of keypairs.
-#
+# Determine default parameters for ssl
 class ssl::params {
-  case $::osfamily {
-    'debian': {
-      $ssl_dir              = '/etc/ssl'
-      $ssl_certdir          = "${ssl_dir}/certs"
-      $ssl_keydir           = "${ssl_dir}/private"
-      $ssl_default_certpath = "${ssl_certdir}/ssl-cert-snakeoil.pem"
-      $ssl_default_keypath  = "${ssl_keydir}/ssl-cert-snakeoil.key"
-    }
-    'redhat': {
-      $ssl_dir              = '/etc/pki'
-      $ssl_certdir          = "${ssl_dir}/certs"
-      $ssl_keydir           = "${ssl_dir}/private"
-      $ssl_default_certpath = "${ssl_certdir}/localhost.crt"
-      $ssl_default_keypath  = "${ssl_keydir}/localhost.key"
-    }
-    'freebsd': {
-      $ssl_dir              = '/etc/ssl'
-      $ssl_certdir          = "${ssl_dir}/certs"
-      $ssl_keydir           = "${ssl_dir}/private"
-      $ssl_default_certpath = "${ssl_certdir}/localhost.crt"
-      $ssl_default_keypath  = "${ssl_keydir}/localhost.key"
-    }
-    default: {
-      notice("ssl::params does not support ${::osfamily}.")
-    }
+  $ssl_dir = $facts['os']['family'] ? {
+    'Debian'  => '/etc/ssl',
+    'RedHat'  => '/etc/pki',
+    'FreeBSD' => '/etc/ssl',
+    default   => fail("ssl module doesn't support OS family ${facts['os']['family']}"),
   }
 
+  $cert_dir = "${ssl_dir}/certs"
+  $key_dir = "${ssl_dir}/private"
+
+  # Don't use these.
+  #
   # This class cannot use the standard data binding lookup because ssl_path
   # is interpolated into the other values and thus must be loaded into scope
   # first.
-  #
-  # We should prepare to deprecate these first few variables
-  warning('hiera calls in the ssl module are being deprecated.  Please update your manifests to use hte variables from the ssl class.')
-  $ssl_path       = $ssl_dir
-  $ssl_cert_file  = hiera('ssl::params::ssl_cert_file', undef)
-  $ssl_chain_file = hiera('ssl::params::ssl_chain_file', undef)
-  $ssl_key_file   = hiera('ssl::params::ssl_key_file', undef)
-  $ssl_ciphers    = hiera('ssl::params::ssl_ciphers', undef)
+  $ssl_path = $ssl_dir
+  $_lookup_options = { default_value => undef }
+  $ssl_cert_file = lookup('ssl::params::ssl_cert_file', $_lookup_options)
+  $ssl_chain_file = lookup('ssl::params::ssl_chain_file', $_lookup_options)
+  $ssl_key_file = lookup('ssl::params::ssl_key_file', $_lookup_options)
+  $ssl_ciphers = lookup('ssl::params::ssl_ciphers', $_lookup_options)
 }


### PR DESCRIPTION
This makes two big changes.

 1. It refactors `ssl::cert`. There is now as `ssl::cert`, an `ssl::cert:haproxy`, and an already deprecated `ssl::cert::nginx`.
 2. It expects SSL certs to be stored under the `files/` directory in a normal profile, and it expects keys to be added to `ssl::keys` in hiera (presumably using hiera eyaml).

See README.markdown.